### PR TITLE
Fixing RedisDbRepository need on NeoSharpRepository (#161)

### DIFF
--- a/src/NeoSharp.Application/DI/PersistenceModule.cs
+++ b/src/NeoSharp.Application/DI/PersistenceModule.cs
@@ -12,30 +12,11 @@ namespace NeoSharp.Application.DI
             containerBuilder.RegisterSingleton<PersistenceConfig>();
             containerBuilder.RegisterSingleton<IRepository, NeoSharpRepository>();
 
-            if (PersistenceConfig.Instance().BinaryStorageProvider == BinaryStorageProvider.RocksDb)
-            {
-                // register RocksDbBinaryRepository
-                containerBuilder.RegisterSingleton<RocksDbConfig>();
-                containerBuilder.RegisterSingleton<IRocksDbRepository, RocksDbRepository>();
-            }
+            containerBuilder.RegisterSingleton<RocksDbConfig>();
+            containerBuilder.RegisterSingleton<IRocksDbRepository, RocksDbRepository>();
 
-            if (PersistenceConfig.Instance().BinaryStorageProvider == BinaryStorageProvider.RedisDb)
-            {
-                // register redisDbBinaryRepository
-                containerBuilder.RegisterSingleton<RedisDbConfig>();
-                containerBuilder.RegisterSingleton<IRedisDbRepository, RedisDbRepository>();
-            }
-
-            if (PersistenceConfig.Instance().JsonStorageProvider == JsonStorageProvider.RedisDb)
-            {
-                // register RedisDbJsonRepository
-                containerBuilder.RegisterSingleton<RedisDbRepository>();
-            }
-
-            if (PersistenceConfig.Instance().JsonStorageProvider == JsonStorageProvider.MongoDb)
-            {
-                // register MongoDbJsonRepository
-            }
+            containerBuilder.RegisterSingleton<RedisDbConfig>();
+            containerBuilder.RegisterSingleton<IRedisDbRepository, RedisDbRepository>();
         }
     }
 }

--- a/src/NeoSharp.Application/appsettings.mainnet.json
+++ b/src/NeoSharp.Application/appsettings.mainnet.json
@@ -1,35 +1,40 @@
 ﻿{
-    "network":
-    {
-        "magic": 7630401,
-        "port": 8000,
-        "forceIPv6": false,
-        "peerEndPoints":
-        [
-            "tcp://seed1.neo.org:10333",
-            "tcp://seed2.neo.org:10333",
-            "tcp://seed3.neo.org:10333",
-            "tcp://seed4.neo.org:10333",
-            "tcp://seed5.neo.org:10333"
-        ],
-        "acl":
-        {
-            "path": "network-acl.json",
-            "type": "Blacklist"
-        }
-    },
-    "rpc":
-    {
-        "listenEndPoint": "127.0.0.1,10332",
-        "#ssl":
-        {
-            "path": "./rpc-ssl.cert",
-            "password": "changeme"
-        },
-        "acl":
-        {
-            "path": "rpc-acl.json",
-            "type": "Blacklist"
-        }
+  "network": {
+    "magic": 7630401,
+    "port": 8000,
+    "forceIPv6": false,
+    "peerEndPoints": [
+      "tcp://seed1.neo.org:10333",
+      "tcp://seed2.neo.org:10333",
+      "tcp://seed3.neo.org:10333",
+      "tcp://seed4.neo.org:10333",
+      "tcp://seed5.neo.org:10333"
+    ],
+    "acl": {
+      "path": "network-acl.json",
+      "type": "Blacklist"
     }
+  },
+  "rpc": {
+    "listenEndPoint": "127.0.0.1,10332",
+    "#ssl": {
+      "path": "./rpc-ssl.cert",
+      "password": "changeme"
+    },
+    "acl": {
+      "path": "rpc-acl.json",
+      "type": "Blacklist"
+    }
+  },
+  "persistence": {
+    "binaryStorageProvider": "RocksDb",
+    "jsonStorageProvider": "None",
+    "rocksDbProvider": {
+      "filePath": "localhost"
+    },
+    "redidDbProvider": {
+      "connectionString": "localhost",
+      "databaseId": "0"
+    }
+  }
 }

--- a/src/NeoSharp.Application/appsettings.testnet.json
+++ b/src/NeoSharp.Application/appsettings.testnet.json
@@ -1,35 +1,40 @@
 ﻿{
-    "network":
-    {
-        "magic": 1953787457,
-        "port": 8000,
-        "forceIPv6": false,
-        "peerEndPoints":
-        [
-            "tcp://seed1.neo.org:20333",
-            "tcp://seed2.neo.org:20333",
-            "tcp://seed3.neo.org:20333",
-            "tcp://seed4.neo.org:20333",
-            "tcp://seed5.neo.org:20333"
-        ],
-        "acl":
-        {
-            "path": "network-acl.json",
-            "type": "Blacklist"
-        }
-    },
-    "rpc":
-    {
-        "listenEndPoint": "127.0.0.1,10332",
-        "#ssl":
-        {
-            "path": "./rpc-ssl.cert",
-            "password": "changeme"
-        },
-        "acl":
-        {
-            "path": "rpc-acl.json",
-            "type": "Blacklist"
-        }
+  "network": {
+    "magic": 1953787457,
+    "port": 8000,
+    "forceIPv6": false,
+    "peerEndPoints": [
+      "tcp://seed1.neo.org:20333",
+      "tcp://seed2.neo.org:20333",
+      "tcp://seed3.neo.org:20333",
+      "tcp://seed4.neo.org:20333",
+      "tcp://seed5.neo.org:20333"
+    ],
+    "acl": {
+      "path": "network-acl.json",
+      "type": "Blacklist"
     }
+  },
+  "rpc": {
+    "listenEndPoint": "127.0.0.1,10332",
+    "#ssl": {
+      "path": "./rpc-ssl.cert",
+      "password": "changeme"
+    },
+    "acl": {
+      "path": "rpc-acl.json",
+      "type": "Blacklist"
+    }
+  },
+  "persistence": {
+    "binaryStorageProvider": "RocksDb",
+    "jsonStorageProvider": "None",
+    "rocksDbProvider": {
+      "filePath": "localhost"
+    },
+    "redidDbProvider": {
+      "connectionString": "localhost",
+      "databaseId": "0"
+    }
+  }
 }

--- a/src/NeoSharp.Persistence.RedisDB/RedisDbRepository.cs
+++ b/src/NeoSharp.Persistence.RedisDB/RedisDbRepository.cs
@@ -32,10 +32,14 @@ namespace NeoSharp.Persistence.RedisDB
             var host = string.IsNullOrEmpty(config.ConnectionString) ? "localhost" : config.ConnectionString;
             var dbId = config.DatabaseId ?? 0;
 
-            //Make the connection to the specified server and database
-            if (_redis == null)
+            if (this._persistenceConfig.BinaryStorageProvider == BinaryStorageProvider.RedisDb ||
+                this._persistenceConfig.JsonStorageProvider == JsonStorageProvider.RedisDb)
             {
-                _redis = new RedisHelper(host, dbId);
+                //Make the connection to the specified server and database
+                if (_redis == null)
+                {
+                    _redis = new RedisHelper(host, dbId);
+                }
             }
         }
         #endregion


### PR DESCRIPTION
* registration of persistence components

* delete unused classes

* * NeoSharpRepository superclass added to expose the IRepository interface to the Application
* Register RedisDb and RockDb with their own interface based on the IRepository interface
* Hook the NeoSharpRepository in the Blockchain AddBlock is called.

* adding the persistence configuration to mainnet and testnet appsettings files

* * RedisDb should not initialize when it's not configured
*The NeoSharpRepository need the RedisDbRepository to be register all the time.

The logic of using the RedisDbRepository is made in the NeoSharpRepository